### PR TITLE
Correcting the logic to conditionally pull the acquisition program.

### DIFF
--- a/lib/scrape.py
+++ b/lib/scrape.py
@@ -75,7 +75,13 @@ class Scraper:
         topic.areas = [ x.strip() for x in meta_rows[4].findAll('td')[1]\
             .contents[0].string.split(',') ]
         topic.url = "%s=%s" % (URL_TOPIC_BASE, topic_id)
-        topic.acquisition_program = rows[0].findAll('td')[1].contents[0].string
+
+        acq_header = soup.find(text=re.compile("Acquisition Program:"))
+        if acq_header is not None:
+            acq_field = acq_header.parent.parent.parent.next_sibling\
+                .contents[0].string
+            if acq_field is not None:
+                topic.acquisition_program = acq_field.strip()
 
         obj_header = soup.find(text=re.compile("Objective:"))
         topic.objective = obj_header.parent.parent.parent.next_sibling\


### PR DESCRIPTION
Previously, the code was expecting the second column of the first
row to always contain the acquisition program information.
Unfortunately, this isn't always the case; many topics do not
contain this information. Furthermore, the markup for the site
does not consistently use `<tr>` tags as expected.

This commit pulls the acquisition program information in a manner
similar to the way the rest of the information is pulled; it finds
the `Acquisition Program:` header and pulls information from the
next field if any is present. This changes the results slightly.
Previously, topics like 'AF151-032' would have the ITAR notification
pulled as the acquisition program. Now the resulting topic object does
not have an `acquisition_program` property.
